### PR TITLE
add 'dot' style for exposure time

### DIFF
--- a/assets/skins/dark/dark.css
+++ b/assets/skins/dark/dark.css
@@ -119,6 +119,11 @@
 .flickr-exif-icon-exposuretime .flickr-exif-icon-text-9 {
     background-position: -90px;
 }
+.flickr-exif-icon-fnumber .flickr-exif-icon-text-dot {
+    background-position: -107px;
+    background-size: 120px;
+    width: 6px;
+}
 .flickr-exif-icon-iso {
     padding: 1px 5px;
 }


### PR DESCRIPTION
fix for 
http://blog.drikin.com/2013/02/flickrex.html
this page

dot style was missing so was coming up as '0'
